### PR TITLE
add 404 page & fix misspelling

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,7 +17,7 @@ not-found: Not found
 index:
   links:
     github:
-      description: Orgnization
+      description: Organization
     qq:
       description: |
         862671480 Tech Group
@@ -27,7 +27,7 @@ index:
     bilibili:
       description: Public tag
     youtube:
-      description: Orgnization account
+      description: Organization account
     telegram:
       description: For chats
     discord:

--- a/src/pages/404.vue
+++ b/src/pages/404.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const { t } = useI18n()
+</script>
+
+<template>
+  <div>
+    {{ t('not-found') }}
+  </div>
+</template>
+
+<route lang="yaml">
+meta:
+  layout: 404
+</route>


### PR DESCRIPTION
`Orgnization` -> `Organization`

`[...all].vue` does not work in github pages

**To customize the 404 page**
1. add 404.vue to generate a 404.html in the root directory
2. create an empty .nojekyll file in the root directory of gh-pages branch
3. rerun github actions

see:
- https://docs.github.com/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site
- https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/