### PR TITLE
mod transition of Accordion.vue

### DIFF
--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -57,7 +57,7 @@ const renderBody = () => h(
     h('div', {
       class: {
         'max-h-0 scale-y-0': it.props?.name !== checkedRow,
-        'p-4 max-h-400': it.props?.name === checkedRow,
+        'max-h-400': it.props?.name === checkedRow,
         'transition-all duration-500': true,
       },
     }, it),

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -27,7 +27,12 @@ const renderButton = (name: string, title: string) => h(
       name,
       value: name,
       class: 'display-none',
-      onclick: () => { checkedRow = name },
+      onclick: () => {
+        if (checkedRow === name)
+          checkedRow = ''
+        else
+          checkedRow = name
+      },
     }, {}),
     title,
   ],
@@ -44,16 +49,16 @@ const renderBody = () => h(
   },
   slots.default && slots.default().map(it => h('div', {
     class: {
-      'overflow-hidden transition-all': true,
+      'overflow-hidden transition-all duration-500': true,
     },
   },
   [
     renderButton(it.props?.name, it.props?.title),
     h('div', {
       class: {
-        'transition-all duration-500': true,
-        'h-0 scale-y-0': it.props?.name !== checkedRow,
-        'p-4': it.props?.name === checkedRow,
+        'max-h-0 scale-y-0': it.props?.name !== checkedRow,
+        'p-8 max-h-400': it.props?.name === checkedRow,
+        'transition-max-h duration-500': true,
       },
     }, it),
   ])),
@@ -66,3 +71,4 @@ const renderBody = () => h(
     <renderBody />
   </AnimateComponent>
 </template>
+

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -57,8 +57,8 @@ const renderBody = () => h(
     h('div', {
       class: {
         'max-h-0 scale-y-0': it.props?.name !== checkedRow,
-        'p-8 max-h-400': it.props?.name === checkedRow,
-        'transition-max-h duration-500': true,
+        'p-4 max-h-400': it.props?.name === checkedRow,
+        'transition-all duration-500': true,
       },
     }, it),
   ])),

--- a/src/components/accordion/AccordionRow.vue
+++ b/src/components/accordion/AccordionRow.vue
@@ -6,5 +6,7 @@ defineProps<{
 </script>
 
 <template>
-  <slot />
+  <div p-4>
+    <slot />
+  </div>
 </template>


### PR DESCRIPTION
@widcardw @TonyCrane 稍微优化了一下折叠面板
1. 同一个面板可以反复折叠和取消折叠
2. 折叠面板的动画更连贯了（之前的 `transition` 无法应用 `height` 从 `0` 到 `auto` ，因此动画是不连贯的）

已知问题：
1. 上面第二点可能有更优雅的实现方式，当前使用 `max-height` 的方式无法应对页面极端窄情况，可能会出现遮挡
2. 经过开发工具测试，上述极端情况即便在像 iphone SE 这样窄屏手机（横向 375 个像素）上都不会出现遮挡，因此估计可以覆盖绝大部分设备
3. 如果后继面板内容高度更高了，就可能得修改 `max-h-400` 为更大值